### PR TITLE
Backup files are not tracking in git anymore

### DIFF
--- a/src/DotenvEditor.php
+++ b/src/DotenvEditor.php
@@ -39,10 +39,7 @@ class DotenvEditor
             return false;
         }
 
-        if(!is_dir($backupPath)){
-            mkdir($backupPath, 0777, true);
-        }
-        $this->backupPath = $backupPath;
+        $this->setBackupPath($backupPath);
     }
 
     /*
@@ -70,9 +67,12 @@ class DotenvEditor
      * @return bool
      */
     public function setBackupPath($path){
+        $path = rtrim($path, DIRECTORY_SEPARATOR);
+        $path .= DIRECTORY_SEPARATOR;
         if(!is_dir($path)){
             try {
                 mkdir($path, 0777, true);
+                file_put_contents($path . '.gitignore', "*\n!.gitignore\n");
             }catch(InvalidPathException $e){
                 echo $e->getMessage();
                 return false;

--- a/src/config/dotenveditor.php
+++ b/src/config/dotenveditor.php
@@ -15,8 +15,8 @@ return [
     | Change the paths, so they fit your needs
     |
     */
-    'pathToEnv'         =>  base_path() . '/.env',
-    'backupPath'        =>  base_path() . '/resources/backups/dotenv-editor/', // Make sure, you have a "/" at the end
+    'pathToEnv'         =>  base_path('.env'),
+    'backupPath'        =>  base_path('resources/backups/dotenv-editor'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
- `.gitignore` file is creating with backup directory to prevent git commit of sensitive environment data in git repositories.
- Cleaned up config paths.
- Removed requirement to have trailing slash at the end of backup path.
