### PR TITLE
Add default values to constructor

### DIFF
--- a/src/DotenvEditor.php
+++ b/src/DotenvEditor.php
@@ -31,8 +31,8 @@ class DotenvEditor
      */
     public function __construct()
     {
-        $backupPath = config('dotenveditor.backupPath',base_path() . '/.env');
-        $env = config('dotenveditor.pathToEnv',base_path() . '/resources/backups/dotenv-editor/');
+        $backupPath = config('dotenveditor.backupPath', base_path() . '/resources/backups/dotenv-editor/');
+        $env = config('dotenveditor.pathToEnv', base_path() . '/.env');
 
         if(file_exists($env)){
             $this->env = $env;

--- a/src/DotenvEditor.php
+++ b/src/DotenvEditor.php
@@ -31,8 +31,8 @@ class DotenvEditor
      */
     public function __construct()
     {
-        $backupPath = config('dotenveditor.backupPath');
-        $env = config('dotenveditor.pathToEnv');
+        $backupPath = config('dotenveditor.backupPath',base_path() . '/.env');
+        $env = config('dotenveditor.pathToEnv',base_path() . '/resources/backups/dotenv-editor/');
 
         if(file_exists($env)){
             $this->env = $env;


### PR DESCRIPTION
Add default values for $env and $backupPath to the constructor, so it works without publishing the config with 
php artisan vendor:publish