### PR TITLE
Exlude repository files out of the downloads.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@
 
 /images export-ignore
 /.gitignore export-ingore
+/.gitatributes
 /README.md export ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Exclude fileswhen the package is downloaded.
+
+/images export-ignore
+/.gitignore export-ingore
+/README.md export ignore


### PR DESCRIPTION
This excludes are setting up. So the files specific for the repository.
Aren't in the vendor directory. What size a little amount of space on
server(s).

And in my opinion these files doesn't belong in production env's.