### PR TITLE
[FEAT]: Support for laravel package discovery.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,15 @@
         "psr-4": {
             "Brotzka\\DotenvEditor\\": "src/"
         }
-    }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Brotzka\\DotenvEditor\\DotenvEditorServiceProvider"
+            ],
+            "aliases": {
+                "DotenvEditor": "Brotzka\\DotenvEditor\\DotenvEditorFacade"
+            }
+        }
+    },
 }


### PR DESCRIPTION
Register the auto discovery for installation on Laravel 5.5 and greater