### PR TITLE
Misspelled config name in mergeConfigFrom

### DIFF
--- a/src/DotenvEditorServiceProvider.php
+++ b/src/DotenvEditorServiceProvider.php
@@ -18,7 +18,7 @@ class DotenvEditorServiceProvider extends ServiceProvider
             return new DotenvEditor();
         });
 
-        $this->mergeConfigFrom(__DIR__ . '/config/dotenveditor.php', 'brotzka-dotenveditor');
+        $this->mergeConfigFrom(__DIR__ . '/config/dotenveditor.php', 'dotenveditor');
     }
 
     public function boot(){


### PR DESCRIPTION
The config is referenced as config('dotenveditor') in all project files requiring config values, but was named 'brotzka-dotenveditor' in the mergeConfigFrom function. So it never got loaded and all calls to config('dotenveditor') returned default values from the vendor/config/dotenveditor.php