### PR TITLE
Set default File Permission to 0755

### DIFF
--- a/src/config/dotenveditor.php
+++ b/src/config/dotenveditor.php
@@ -17,7 +17,7 @@ return [
     */
     'pathToEnv'         =>  base_path() . '/.env',
     'backupPath'        =>  base_path() . '/resources/backups/dotenv-editor/', // Make sure, you have a "/" at the end
-    'filePermissions'   =>  env('FILE_PERMISSIONS', 0777),
+    'filePermissions'   =>  env('FILE_PERMISSIONS', 0755),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
File Permission 0777 is evil!
See https://askubuntu.com/questions/20105/why-shouldnt-var-www-have-chmod-777 for details 
Anyone should ever use 0777 on a web server!