### PR TITLE
Fix Routes class not exists bug: Use provider app instance to create routes.

### DIFF
--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,29 +1,24 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Fabian
- * Date: 19.07.16
- * Time: 06:04
- */
 
 if(config('dotenveditor.activated')){
-    Route::group([
+    
+    $this->app->group([
         'middleware' => config('dotenveditor.middleware'),
         'middlewareGroups' => config('dotenveditor.middlewareGroups')
     ],
         function(){
-            Route::get(config('dotenveditor.route'), 'Brotzka\DotenvEditor\Http\Controller\EnvController@overview');
-            Route::post(config('dotenveditor.route') . '/add', 'Brotzka\DotenvEditor\Http\Controller\EnvController@add');
-            Route::post(config('dotenveditor.route') . '/update', 'Brotzka\DotenvEditor\Http\Controller\EnvController@update');
-            Route::get(config('dotenveditor.route') . '/createbackup', 'Brotzka\DotenvEditor\Http\Controller\EnvController@createBackup');
-            Route::get(config('dotenveditor.route') . '/deletebackup/{timestamp}', 'Brotzka\DotenvEditor\Http\Controller\EnvController@deleteBackup');
+            $this->app->get(config('dotenveditor.$this->app->'), 'Brotzka\DotenvEditor\Http\Controller\EnvController@overview');
+            $this->app->post(config('dotenveditor.$this->app->') . '/add', 'Brotzka\DotenvEditor\Http\Controller\EnvController@add');
+            $this->app->post(config('dotenveditor.$this->app->') . '/update', 'Brotzka\DotenvEditor\Http\Controller\EnvController@update');
+            $this->app->get(config('dotenveditor.$this->app->') . '/createbackup', 'Brotzka\DotenvEditor\Http\Controller\EnvController@createBackup');
+            $this->app->get(config('dotenveditor.$this->app->') . '/deletebackup/{timestamp}', 'Brotzka\DotenvEditor\Http\Controller\EnvController@deleteBackup');
 
-            Route::get(config('dotenveditor.route') . '/restore/{backuptimestamp}', 'Brotzka\DotenvEditor\Http\Controller\EnvController@restore');
-            Route::post(config('dotenveditor.route') . '/delete', 'Brotzka\DotenvEditor\Http\Controller\EnvController@delete');
-            Route::get(config('dotenveditor.route') . '/download/{filename?}', 'Brotzka\DotenvEditor\Http\Controller\EnvController@download');
-            Route::post(config('dotenveditor.route') . '/upload', 'Brotzka\DotenvEditor\Http\Controller\EnvController@upload');
-            Route::get(config('dotenveditor.route') . '/getdetails/{timestamp?}', 'Brotzka\DotenvEditor\Http\Controller\EnvController@getDetails');
+            $this->app->get(config('dotenveditor.$this->app->') . '/restore/{backuptimestamp}', 'Brotzka\DotenvEditor\Http\Controller\EnvController@restore');
+            $this->app->post(config('dotenveditor.$this->app->') . '/delete', 'Brotzka\DotenvEditor\Http\Controller\EnvController@delete');
+            $this->app->get(config('dotenveditor.$this->app->') . '/download/{filename?}', 'Brotzka\DotenvEditor\Http\Controller\EnvController@download');
+            $this->app->post(config('dotenveditor.$this->app->') . '/upload', 'Brotzka\DotenvEditor\Http\Controller\EnvController@upload');
+            $this->app->get(config('dotenveditor.$this->app->') . '/getdetails/{timestamp?}', 'Brotzka\DotenvEditor\Http\Controller\EnvController@getDetails');
 
-            Route::get(config('dotenveditor.route') . '/test', 'Brotzka\DotenvEditor\Http\Controller\EnvController@test');
+            $this->app->get(config('dotenveditor.$this->app->') . '/test', 'Brotzka\DotenvEditor\Http\Controller\EnvController@test');
         });
 }


### PR DESCRIPTION
Change static usage of Route and use the service provider instance to
make the routes.