### PR TITLE
Resolves blank line in env error #42

### DIFF
--- a/src/DotenvEditor.php
+++ b/src/DotenvEditor.php
@@ -320,7 +320,7 @@ class DotenvEditor
         $returnArray = array();
 
         foreach($string as $one){
-            if (preg_match('/^(#\s)/', $one) === 1) {
+            if (preg_match('/^(#\s)/', $one) === 1 || preg_match('/^([\\n\\r]+)/', $one)) {
                 continue;
             }
             $entry = explode("=", $one, 2);


### PR DESCRIPTION
The issue that I found was that when the .env file had one or more blanks lines passing it through `envToArray()` would return an array with a key of `[0=>'\r']`.

This key would result in the output .env file having a single line of with only `=` resulting in the `putenv(): Invalid parameter syntax` error.

This fix uses a regex expression to detect if the `$env` string starts with a return character and skips building an array key for that string, however, the resulting output is missing all line breaks. Alternatively, you could check that the string includes an equals sign.
