### PR TITLE
Remove duplicate import of Illuminate\Support\Str

### DIFF
--- a/src/DotenvEditor.php
+++ b/src/DotenvEditor.php
@@ -11,7 +11,6 @@ namespace Brotzka\DotenvEditor;
 use Illuminate\Support\Str;
 use Brotzka\DotenvEditor\Exceptions\DotEnvException;
 use Dotenv\Exception\InvalidPathException;
-use Illuminate\Support\Str;
 
 class DotenvEditor
 {


### PR DESCRIPTION
Latest release of the package resulted in duplicate Str include - one on line 11 and one on line 14. This triggers error and breaks the functinality. This PR removes the duplicate line
```
use  Illuminate\Support\Str;
```