### PR TITLE
Fix Illuminate\Support\Str already used  Error

### DIFF
--- a/src/DotenvEditor.php
+++ b/src/DotenvEditor.php
@@ -11,7 +11,6 @@ namespace Brotzka\DotenvEditor;
 use Illuminate\Support\Str;
 use Brotzka\DotenvEditor\Exceptions\DotEnvException;
 use Dotenv\Exception\InvalidPathException;
-use Illuminate\Support\Str;
 
 class DotenvEditor
 {


### PR DESCRIPTION
Cannot use Illuminate\Support\Str as Str because the name is already in use. Declared on line 11 and 14.